### PR TITLE
Increase group and block limits

### DIFF
--- a/aiohelvar/parser/address.py
+++ b/aiohelvar/parser/address.py
@@ -43,7 +43,7 @@ class HelvarAddress:
 
         var = int(var)
         if var < 0 or var > 253:
-            raise TypeError("Block must be between 1 and 4.")
+            raise TypeError("Block must be between 1 and 253.")
         self.__block = var
 
     @property
@@ -120,8 +120,8 @@ class SceneAddress:
 
     Address format is @g.b.c
 
-    g - Group (0-128)
-    b - Block (1-8)
+    g - Group (0-?)
+    b - Block (1-?)
     s - Scene (1-16)
 
     group 0 == Un-grouped
@@ -146,8 +146,8 @@ class SceneAddress:
     def group(self, var):
 
         var = int(var)
-        if var < 0 or var > 128:
-            raise TypeError("Group must be between 0 and 128.")
+        if var < 0 or var > 512:
+            raise TypeError("Group must be between 0 and 512.")
         self.__group = var
 
     @property
@@ -158,8 +158,8 @@ class SceneAddress:
     def block(self, var):
 
         var = int(var)
-        if var < 1 or var > 8:
-            raise TypeError("Block must be between 1 and 8.")
+        if var < 1 or var > 253:
+            raise TypeError("Block must be between 1 and 253.")
         self.__block = var
 
     @property


### PR DESCRIPTION
(I believe this is a single digidim 920 router, but with DMX.)

I seem to have sparse group list with highest numbers all the way to 400:
```bash
    Group 401: Lohko 1. Has 0 devices.
    Group 402: Lohko 2. Has 0 devices.
    Group 403: Lohko 3. Has 0 devices.
```

Blocks were also giving an error, got this, increased the value to the value of the other block limit in the file, but don't know if that is the same "block" as the other one:

`TypeError: Block must be between 1 and 8, was 17.`