### PR TITLE
Add QUERY_INPUTS command type

### DIFF
--- a/aiohelvar/devices.py
+++ b/aiohelvar/devices.py
@@ -1,5 +1,6 @@
 from aiohelvar.lib import Subscribable
 from aiohelvar.parser.parser import CommandParser
+from aiohelvar.router import Router
 from .static import (
     DALI_TYPES,
     DEVICE_STATE_FLAGS,
@@ -213,7 +214,7 @@ class Device(Subscribable):
 
 class Devices:
     devices: dict[HelvarAddress,Device]
-
+    router: Router
     def __init__(self, router):
         self.router = router
         self.devices = {}
@@ -306,8 +307,10 @@ class Devices:
     async def query_inputs(self, device: Device) -> list[bool] | None:
         """Send a QUERY_INPUTS command to the given address, 
             returns a variable list of booleans of input responses, 
-            or the raw response string if it contains unexpected characters,
-            or None if we don't get a response."""
+            throws aiohelvar.exceptions.PropertyDoesNotExistError
+            if the address doesn't support querying inputs.
+
+            Returns None if we don't get a response for some reason."""
         future = await self.router.send_command(
             Command(CommandType.QUERY_INPUTS, command_address=device.address),
             throw_error=True
@@ -331,13 +334,16 @@ class Devices:
                     CommandType.QUERY_DEVICE_DESCRIPTION, command_address=device.address
                 )
             )
-            await self.update_device_name(device.address, response.result)
+            if response:
+                await self.update_device_name(device.address, response.result)
 
         async def update_state(device):
             response = await self.router._send_command_task(
                 Command(CommandType.QUERY_DEVICE_STATE, command_address=device.address)
             )
-            await self.update_device_state(device.address, response.result)
+
+            if response:
+               await self.update_device_state(device.address, response.result)
 
         async def update_load_level(device):
             response = await self.router._send_command_task(
@@ -345,13 +351,15 @@ class Devices:
                     CommandType.QUERY_DEVICE_LOAD_LEVEL, command_address=device.address
                 )
             )
-            await self.update_device_load_level(device.address, response.result)
+            if response:
+                await self.update_device_load_level(device.address, response.result)
 
         async def update_scene_level(device):
             response = await self.router._send_command_task(
                 Command(CommandType.QUERY_SCENE_INFO, command_address=device.address)
             )
-            self.update_device_scene_level(device.address, response.result)
+            if response:
+                self.update_device_scene_level(device.address, response.result)
 
         asyncio.create_task(update_name(device))
         asyncio.create_task(update_state(device))

--- a/aiohelvar/devices.py
+++ b/aiohelvar/devices.py
@@ -1,4 +1,5 @@
 from aiohelvar.lib import Subscribable
+from aiohelvar.parser.parser import CommandParser
 from .static import (
     DALI_TYPES,
     DEVICE_STATE_FLAGS,
@@ -178,7 +179,7 @@ class Device(Subscribable):
             self.protocol = UNKNOWN_PROTOCOL
             _LOGGER.error(
                 UnrecognizedCommand(
-                    None, f"Known device type {bytes} for address {self.address}."
+                    None, f"Unknown device type {bytes} for address {self.address}."
                 )
             )
 
@@ -211,6 +212,8 @@ class Device(Subscribable):
 
 
 class Devices:
+    devices: dict[HelvarAddress,Device]
+
     def __init__(self, router):
         self.router = router
         self.devices = {}
@@ -299,6 +302,23 @@ class Devices:
             # await devices.update_device_load_level(address, response.result)
 
         asyncio.create_task(task(self, address, load_level))
+
+    async def query_inputs(self, device: Device) -> list[bool] | None:
+        """Send a QUERY_INPUTS command to the given address, 
+            returns a variable list of booleans of input responses, 
+            or the raw response string if it contains unexpected characters,
+            or None if we don't get a response."""
+        future = await self.router.send_command(
+            Command(CommandType.QUERY_INPUTS, command_address=device.address),
+            throw_error=True
+        )
+        r_command = await future
+        if not r_command:
+            return None
+        return CommandParser._parse_query_inputs_response(r_command.result)
+        
+                
+    
 
     async def update_device(self, address):
         # Update name, state and load.

--- a/aiohelvar/devices.py
+++ b/aiohelvar/devices.py
@@ -1,6 +1,5 @@
 from aiohelvar.lib import Subscribable
 from aiohelvar.parser.parser import CommandParser
-from aiohelvar.router import Router
 from .static import (
     DALI_TYPES,
     DEVICE_STATE_FLAGS,
@@ -214,7 +213,6 @@ class Device(Subscribable):
 
 class Devices:
     devices: dict[HelvarAddress,Device]
-    router: Router
     def __init__(self, router):
         self.router = router
         self.devices = {}

--- a/aiohelvar/exceptions.py
+++ b/aiohelvar/exceptions.py
@@ -1,3 +1,7 @@
+from .parser.command_type import MessageType
+from .parser.command import Command
+
+
 class Error(Exception):
     """Base class for exceptions in this module."""
 
@@ -29,3 +33,142 @@ class CommandResponseTimeout(Error):
 
     def __init__(self, command):
         self.expression = command
+
+
+# HelvarNet exceptions
+class HelvarNetError(Error):
+    error_id: int = -1
+    description: str = "Unknown description"
+
+    def __init__(self,error_id: int|None=None):
+        if error_id:
+            self.error_id = error_id
+        super().__init__(f"[{self.error_id}] {self.description}")
+    def __str__(self) -> str:
+        return f"[{self.error_id}] {self.description}"
+
+class InvalidGroupIndexParameterError(HelvarNetError):
+    error_id = 1
+    description = "Invalid group index parameter"
+
+
+class InvalidClusterParameterError(HelvarNetError):
+    error_id = 2
+    description = "Invalid cluster parameter"
+
+
+class InvalidRouterParameterError(HelvarNetError):
+    error_id = 3
+    description = "Invalid router parameter"
+
+
+class InvalidSubnetParameterError(HelvarNetError):
+    error_id = 4
+    description = "Invalid subnet parameter"
+
+
+class InvalidDeviceParameterError(HelvarNetError):
+    error_id = 5
+    description = "Invalid device parameter"
+
+
+class InvalidSubDeviceParameterError(HelvarNetError):
+    error_id = 6
+    description = "Invalid sub device parameter"
+
+
+class InvalidBlockParameterError(HelvarNetError):
+    error_id = 7
+    description = "Invalid block parameter"
+
+
+class InvalidSceneParameterError(HelvarNetError):
+    error_id = 8
+    description = "Invalid scene parameter"
+
+
+class ClusterDoesNotExistError(HelvarNetError):
+    error_id = 9
+    description = "Cluster does not exist"
+
+
+class RouterDoesNotExistError(HelvarNetError):
+    error_id = 10
+    description = "Router does not exist"
+
+
+class DeviceDoesNotExistError(HelvarNetError):
+    error_id = 11
+    description = "Device does not exist"
+
+
+class PropertyDoesNotExistError(HelvarNetError):
+    error_id = 12
+    description = "Property does not exist"
+
+
+class InvalidRawMessageSizeError(HelvarNetError):
+    error_id = 13
+    description = "Invalid RAW message size"
+
+
+class InvalidMessageTypeError(HelvarNetError):
+    error_id = 14
+    description = "Invalid messages type"
+
+
+class InvalidMessageCommandError(HelvarNetError):
+    error_id = 15
+    description = "Invalid message command"
+
+
+class MissingAsciiTerminatorError(HelvarNetError):
+    error_id = 16
+    description = "Missing ASCII terminator"
+
+
+class MissingAsciiParameterError(HelvarNetError):
+    error_id = 17
+    description = "Missing ASCII parameter"
+
+
+class IncompatibleVersionError(HelvarNetError):
+    error_id = 18
+    description = "Incompatible version"
+
+
+_HELVARNET_ERROR_CLASSES: dict[int, type[HelvarNetError]] = {
+    cls.error_id: cls
+    for cls in HelvarNetError.__subclasses__()
+}
+
+def helvarnet_error_by_result(result: int | str | Command) -> HelvarNetError | None:
+    """ Returns a HelvarNetError for a command or a command's error_id.
+    Returns None if the command is not an error."""
+
+    if isinstance(result,Command):
+        if result.command_message_type != MessageType.ERROR:
+            return None
+        result = result.result
+
+    result = int(result) # NOTE: can throw ValueError
+
+    ret = _HELVARNET_ERROR_CLASSES.get(result)
+
+    if not ret and result != 0:
+        ret = HelvarNetError(error_id=result)
+    elif ret:
+        ret = ret()
+
+    return ret
+
+if __name__ == "__main__":
+    err = helvarnet_error_by_result(1)
+    print(f"err: {err}")
+    err = helvarnet_error_by_result(0)
+    assert err is None, f"Expected None for result 0, got {err}"
+    err = helvarnet_error_by_result(9999)
+    print(f"err: {err}")
+    err = HelvarNetError(error_id=9876)
+    err.description = "This is a custom error with an unknown error code."
+    raise err

--- a/aiohelvar/parser/command_type.py
+++ b/aiohelvar/parser/command_type.py
@@ -10,6 +10,7 @@ class CommandType(Enum):
     QUERY_DEVICE_TYPES_AND_ADDRESSES = (100, "Query Device Types and Addresses")
     QUERY_DEVICE_STATE = (110, "Query Device State")
     QUERY_WORKGROUP_NAME = (107, "Query Workgroup Name")
+    QUERY_INPUTS = (151, "Query digital input(s) or state of a device")
     QUERY_DEVICE_LOAD_LEVEL = (152, "Query Device Load Level")
     QUERY_SCENE_INFO = (167, "Query device scene levels.")
     QUERY_ROUTER_TIME = (185, "Query Router Time")

--- a/aiohelvar/parser/parser.py
+++ b/aiohelvar/parser/parser.py
@@ -99,3 +99,14 @@ class CommandParser:
                     )
 
         return parameters
+    
+    @staticmethod
+    def _parse_query_inputs_response(response_string: str) -> list[bool]:
+        """Parse the response string of a QUERY_INPUTS command into a list of booleans.
+            First value in list is the least significant bit.
+            
+           NOTE: Does not know how many bits there should be!"""
+                
+        res = [bit == '1' for bit in bin(int(response_string))[2:]]
+        res.reverse()
+        return res

--- a/aiohelvar/router.py
+++ b/aiohelvar/router.py
@@ -9,7 +9,7 @@ from .parser.command_type import (
     MessageType,
 )
 from .parser.command import Command
-from .exceptions import CommandResponseTimeout, ParserError
+from .exceptions import CommandResponseTimeout, HelvarNetError, ParserError, helvarnet_error_by_result
 import asyncio
 import datetime
 import logging
@@ -72,7 +72,7 @@ class Router:
 
         self.commands_to_send = asyncio.Queue()
 
-        self.commands_received = []
+        self.commands_received: list[Command] = []
         self.command_received = asyncio.Condition()
 
         self.connected = False
@@ -253,7 +253,7 @@ class Router:
 
     #     print(response.result())
 
-    async def _send_command_task(self, command: Command):
+    async def _send_command_task(self, command: Command, throw_error=False) -> Command | None:
 
         start_time = datetime.datetime.now()
 
@@ -265,18 +265,41 @@ class Router:
             We match all command parameters, but we can't guarantee that identical requests don't steal
             eachothers replies."""
 
-            for r_command in self.commands_received:
-                if r_command.type_parameters_address == command.type_parameters_address:
+            for command_resp in self.commands_received:
+                if command_resp.type_parameters_address == command.type_parameters_address:
                     # this is probably our response.
                     # We can safely remove ourselves from list as we stop iterating.
+                    self.commands_received.remove(command_resp)
 
-                    if r_command.command_message_type == MessageType.ERROR:
-                        _LOGGER.error(
-                            f"Request command {command} triggered an error back from the router: {r_command}."
-                        )
+                    if command_resp.command_message_type == MessageType.ERROR:
+                        try:
+                            err = helvarnet_error_by_result(command_resp)
+                        except ValueError:
+                            err = None
 
-                    self.commands_received.remove(r_command)
-                    return r_command
+                        if throw_error:
+                            if err:
+                                
+                                _LOGGER.debug(
+                                    f"Request command {command} triggered an error back from the router: {err}."
+                                )
+
+                                raise err
+                            else:
+                                _LOGGER.error(
+                                    f"Request command {command} triggered an unknown error back from the router: {command_resp} (aiohelvar programming error?)."
+                                )
+                                err = HelvarNetError(error_id=-1)
+                                err.description = f"Unknown error with result {command_resp.result}"
+                                raise err
+
+                        else:
+                            _LOGGER.error(
+                                f"Request command {command} triggered an error back from the router: {err}."
+                            )
+                    
+                        
+                    return command_resp
             return None
 
         if command.command_type in COMMAND_TYPES_DONT_LISTEN_FOR_RESPONSE:
@@ -303,13 +326,13 @@ class Router:
 
         return response
 
-    async def send_command(self, command: Command) -> asyncio.Task:
+    async def send_command(self, command: Command, throw_error=False) -> asyncio.Task[Command|None]:
         """
         Send command, return a future that'll return when we get a response back.
         We don't have request identifiers, so we have to use basic FIFO and
         assume the router executes commands in the order it received them.
         """
-        return asyncio.create_task(self._send_command_task(command))
+        return asyncio.create_task(self._send_command_task(command, throw_error=throw_error))
 
     async def send_string(self, string: str):
         await self.commands_to_send.put(bytes(string, "utf-8"))

--- a/aiohelvar/scenes.py
+++ b/aiohelvar/scenes.py
@@ -33,21 +33,26 @@ class Scenes:
         try:
             self.scenes[scene_address].name = name
         except KeyError:
+            scenes = list(self.scenes.keys())
+            if len(scenes) > 100:
+                scenes = len(scenes)
             _LOGGER.error(
                 f"Cannot update scene name: Scene not found {scene_address} "
                 f"(group={scene_address.group}, block={scene_address.block}, scene={scene_address.scene}). "
-                f"Available scenes: {list(self.scenes.keys())}"
+                f"Available scenes: {scenes}"
             )
 
     def get_scene(self, scene_address):
         try:
             return self.scenes[scene_address]
         except KeyError:
-            
+            sceneinfo = [(str(addr), hash(addr)) for addr in self.scenes.keys()]
+            if len(sceneinfo) > 100:
+                sceneinfo = len(sceneinfo)
             _LOGGER.error(
                 f"Scene not found: {scene_address} (group={scene_address.group}, "
                 f"block={scene_address.block}, scene={scene_address.scene}). "
-                f"Available scenes: {[(str(addr), hash(addr)) for addr in self.scenes.keys()]}"
+                f"Available scenes: {sceneinfo}"
             )
             return None
 

--- a/examples/query_inputs.py
+++ b/examples/query_inputs.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""Queries all devices for their inputs, 
+    and starts polling the devices that had inputs,
+    then prints input state changes to the console.
+
+WARNING: Polling happens every second for every device 
+    so it may slow down the router or do other unwanted things
+    if ran on a large installation!
+"""
+
+import asyncio
+from aiohelvar.router import Router
+import logging
+
+from aiohelvar.parser.parser import CommandParser
+
+import aiohelvar.exceptions
+
+async def main():
+    parser = CommandParser()
+    router_ip_address = "10.254.1.1"
+    router_helvarnet_port = 50000
+
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    logging.getLogger().addHandler(console)
+
+    print(f"Connecting to router at address: {router_ip_address}...")
+    router = Router(router_ip_address, router_helvarnet_port)
+    await router.connect()
+    print(f"Connected to router on workgroup: {router.workgroup_name}. Initializing router...")
+    await router.initialize()
+    print("Initialized router. Devices detected: ", len(router.devices.devices))
+    await asyncio.sleep(2)
+    
+    devices_with_type = [d for d in router.devices.devices.values() if d.type]
+
+    print(f"\nQuerying inputs ({len(devices_with_type)} devices with any device type):")
+    device_state = {}
+    for addr, device in router.devices.devices.items():
+        if not device.type:
+            continue
+        print(f" - {device.name} ( type: {device.type} )")
+        
+        
+        try:
+            response = await router.devices.query_inputs(device)
+            if response:
+                print("     - ",response)
+                device_state[device] = response
+            else:
+                print("     - ","(no response???)")
+        except aiohelvar.exceptions.PropertyDoesNotExistError:
+            print("     - ","N/A")
+
+    print(f"Found {len(device_state)} devices with queryable inputs. Starting polling...")
+    printed_dots = False
+    while True:
+        # print changes in state boolean field list
+        for device, state in device_state.items():
+            try:
+                new_state = await router.devices.query_inputs(device)
+                if new_state != state:
+                    if printed_dots:
+                        printed_dots=False
+                        print()
+                    print(f"Device {device.name} state changed: {state} -> {new_state}")
+                    device_state[device] = new_state
+            except aiohelvar.exceptions.PropertyDoesNotExistError:
+                print(f"Device {device.name} no longer has queryable inputs??")
+                del device_state[device]
+            await asyncio.sleep(0)
+        await asyncio.sleep(1)
+        printed_dots  = True
+        print(".", end="", flush=True)
+
+
+asyncio.run(main())

--- a/examples/query_inputs.py
+++ b/examples/query_inputs.py
@@ -10,13 +10,18 @@ WARNING: Polling happens every second for every device
 """
 
 import asyncio
+from datetime import datetime
 from aiohelvar.router import Router
 import logging
 
 from aiohelvar.parser.parser import CommandParser
 
 import aiohelvar.exceptions
-
+try:
+    from rich import print
+except ImportError:
+    pass
+POLL_INTERVAL = 2.0
 async def main():
     parser = CommandParser()
     router_ip_address = "10.254.1.1"
@@ -47,32 +52,51 @@ async def main():
         try:
             response = await router.devices.query_inputs(device)
             if response:
-                print("     - ",response)
+                print(f"     - {response}")
                 device_state[device] = response
             else:
-                print("     - ","(no response???)")
+                print("     - (no response???)")
         except aiohelvar.exceptions.PropertyDoesNotExistError:
-            print("     - ","N/A")
+            print("     - N/A")
 
     print(f"Found {len(device_state)} devices with queryable inputs. Starting polling...")
     printed_dots = False
+    loop = asyncio.get_running_loop()
     while True:
-        # print changes in state boolean field list
-        for device, state in device_state.items():
+        device_state_loop = list(device_state.items())
+        count = len(device_state_loop)
+
+        if count == 0:
+            print("No devices with queryable inputs.")
+            return
+
+        # Spread the queries evenly across one second
+        interval = POLL_INTERVAL / count
+        start_time = loop.time()
+
+        for i, (device, state) in enumerate(device_state_loop):
+
             try:
                 new_state = await router.devices.query_inputs(device)
                 if new_state != state:
                     if printed_dots:
-                        printed_dots=False
+                        printed_dots = False
                         print()
-                    print(f"Device {device.name} state changed: {state} -> {new_state}")
+                    print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} Inputs changed for {device.name}: {new_state} (old {state})")
                     device_state[device] = new_state
             except aiohelvar.exceptions.PropertyDoesNotExistError:
-                print(f"Device {device.name} no longer has queryable inputs??")
-                del device_state[device]
-            await asyncio.sleep(0)
-        await asyncio.sleep(1)
-        printed_dots  = True
+                print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} Device {device.name} no longer has queryable inputs??")
+                # remove from the live state dict if it's still present
+                device_state.pop(device, None)
+
+            # Calculate when the next task should start and adapt sleep
+            next_start = start_time + ((i + 1) * interval)
+            now = loop.time()
+            delay = next_start - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+        printed_dots = True
         print(".", end="", flush=True)
 
 


### PR DESCRIPTION
Adding the input query command described in HelvarNet documentation along with an example. Not tied to devices themselves yet.

**Related**:
 - https://github.com/tomplayford/aiohelvar/pull/14
    - Information about this gracefully provided [here](https://github.com/tomplayford/aiohelvar/issues/9#issuecomment-3207613612)


**Side-effects of PR**:
 - Added some typing hints for helping with development
 - Added (optional) exception handling to commands 
   - Generated (based on docs) individual exception classes (with copilot), for example `aiohelvar.exceptions.PropertyDoesNotExistError(HelvarNetError)`. This makes typing happier than dynamically generating them.
 - some exception printout fixes so the example runs in [aistikattila](https://aistikattila.fi) Helvar environment without printing thousands of lines of text. (can remove these to cleanup the PR). 
 - new example script for printing input changes

**Problems:**
 - No idea how many answer bits each query may have
 - No idea how to know which devices are queryable (hence the error handling)
 - Only polling available, probably breaks for large installations
 - Put _parse_query_inputs_response in a little bit of a weird place. Should reconsider in case we start collecting device type inputs into structures, assuming they can be collected. Probably fine.
 - exceptions are all in the same file, could be separated but didn't want to add more files for no reason. please advice.
______________

_Obligatory "sponsored" PR disclosure:_

_We gratefully acknowledge the [Flavoria® Multidisciplinary Research Platform](https://www.flavoria.fi/en/) for letting us explore HelvarNet with the Aistikattila's lighting system. Special thanks also goes to https://github.com/AleksiPapalitsas for helping with the aiohelvar integration of Aistikattila._

Also note for others wanting to try aiohelvar in a realistic setting (lights, motion sensors, buttons, etc): _Obviously the Aistikattila room is not primarily meant for experimenting with lighting, but for mutually beneficial (non-commercial?) activities that do not permanently alter the lighting system there, I think they would still be amenable to collaboration even after what all we have done (and probably also for a reasonable usage fee as long as you know how to restore the lighting system back to how it was for normal research). I think it is the only Helvar lighting system at the University of Turku campus that we have any real access to as it is completely separate from the rest of the building and of any emergency lighting._ 